### PR TITLE
Allow overriding Gemini API base URL

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -239,6 +239,9 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Specifies the default Gemini model to use.
   - Overrides the hardcoded default
   - Example: `export GEMINI_MODEL="gemini-2.5-flash"`
+- **`GEMINI_BASE_URL`**:
+  - Overrides the default base URL used for Gemini API requests.
+  - Example: `export GEMINI_BASE_URL="https://my.example.com"`
 - **`GOOGLE_API_KEY`**:
   - Your Google Cloud API key.
   - Required for using Vertex AI in express mode.

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -125,6 +125,7 @@ export async function createContentGenerator(
       apiKey: config.apiKey === '' ? undefined : config.apiKey,
       vertexai: config.vertexai,
       httpOptions,
+      baseUrl: process.env.GEMINI_BASE_URL,
     });
 
     return googleGenAI.models;


### PR DESCRIPTION
## Summary
- permit specifying `GEMINI_BASE_URL` for the generative models
- document new `GEMINI_BASE_URL` env var in configuration guide

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a0f0c1248329969dc366f39e3911